### PR TITLE
Start patching `linkml` to get more correct behavior

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "datalad-concepts"]
+	path = datalad-concepts
+	url = https://github.com/psychoinformatics-de/datalad-concepts.git
+	datalad-url = https://github.com/psychoinformatics-de/datalad-concepts.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ packages = ["dump_things_service"]
 [tool.hatch.version]
 path = "dump_things_service/__about__.py"
 
+[tool.hatch.envs.default]
+post-install-commands = [
+  "{root}/tools/patch_linkml",
+]
+
 [tool.hatch.envs.types]
 extra-dependencies = [
     "mypy>=1.0.0",

--- a/tools/patch_linkml
+++ b/tools/patch_linkml
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script applies patches to the active linkml installation.
+# It is to be executed in the root of the repository.
+#
+
+# Honor type-designator slots when loading graphs
+patch -d $(python -c 'import os; import linkml_runtime.loaders as m; print(os.path.dirname(m.__file__))') < datalad-concepts/patches/rdflib_loader_typedesignator.diff


### PR DESCRIPTION
The patch source is the datalad-concepts repository, which is included as a submodule.

All hatch environments are created with a patched linkml installation automatically.

Closes #32 