### PR TITLE
Extract inlined records before storing a record

### DIFF
--- a/dump_things_service/storage.py
+++ b/dump_things_service/storage.py
@@ -234,8 +234,9 @@ class TokenStorage(Storage):
                 ]
             )
         )
-        record['characterized_by'] = [sub_record['id'] for sub_record in sub_records]
-        del record['relations']
+        record['relations'] = {
+            sub_record['id']: {'id': sub_record['id']} for sub_record in sub_records
+        }
         return [record, *sub_records]
 
 

--- a/dump_things_service/storage.py
+++ b/dump_things_service/storage.py
@@ -203,7 +203,9 @@ class TokenStorage(Storage):
             try:
                 storage_path.relative_to(record_root)
             except ValueError as e:
-                raise HTTPException(status_code=400, detail='Invalid identifier.') from e
+                raise HTTPException(
+                    status_code=400, detail='Invalid identifier.'
+                ) from e
 
             # Ensure all intermediate directories exist and save the yaml document
             storage_path.parent.mkdir(parents=True, exist_ok=True)
@@ -234,7 +236,8 @@ class TokenStorage(Storage):
         )
         record['characterized_by'] = [sub_record['id'] for sub_record in sub_records]
         del record['relations']
-        return [record] + sub_records
+        return [record, *sub_records]
+
 
 def get_class_from_path(path: Path) -> str | None:
     """Determine the class that is defined by `path`.

--- a/dump_things_service/tests/test_extract_inline.py
+++ b/dump_things_service/tests/test_extract_inline.py
@@ -6,7 +6,7 @@ inlined_json_record = {
     'id': 'trr379:root_element',
     'schema_type': 'dlsocial:Person',
     'given_name': 'Grandfather',
-    'relations' : {
+    'relations': {
         'trr379:child_element': {
             'id': 'trr379:child_element',
             'schema_type': 'dlsocial:Person',
@@ -16,10 +16,10 @@ inlined_json_record = {
                     'id': 'trr379:grand_child_element',
                     'schema_type': 'dlsocial:Person',
                     'given_name': 'Son',
-                }
-            }
-        }
-    }
+                },
+            },
+        },
+    },
 }
 
 
@@ -28,9 +28,9 @@ def test_inline_extraction(fastapi_client_simple):
 
     # Deposit JSON record
     response = test_client.post(
-        f'/trr379_store/record/Person',
+        '/trr379_store/record/Person',
         headers={'x-dumpthings-token': 'token_1'},
-        json=inlined_json_record
+        json=inlined_json_record,
     )
     assert response.status_code == HTTP_200_OK
 

--- a/dump_things_service/tests/test_extract_inline.py
+++ b/dump_things_service/tests/test_extract_inline.py
@@ -47,4 +47,4 @@ def test_inline_extraction(fastapi_client_simple):
         assert response.status_code == HTTP_200_OK
         record = response.json()
         if linked_id:
-            assert linked_id in record['characterized_by']
+            assert record['relations'][linked_id] == {'id': linked_id}

--- a/dump_things_service/tests/test_extract_inline.py
+++ b/dump_things_service/tests/test_extract_inline.py
@@ -1,0 +1,50 @@
+import pytest  # noqa F401
+
+from . import HTTP_200_OK
+
+inlined_json_record = {
+    'id': 'trr379:root_element',
+    'schema_type': 'dlsocial:Person',
+    'given_name': 'Grandfather',
+    'relations' : {
+        'trr379:child_element': {
+            'id': 'trr379:child_element',
+            'schema_type': 'dlsocial:Person',
+            'given_name': 'Father',
+            'relations': {
+                'trr379:grand_child_element': {
+                    'id': 'trr379:grand_child_element',
+                    'schema_type': 'dlsocial:Person',
+                    'given_name': 'Son',
+                }
+            }
+        }
+    }
+}
+
+
+def test_inline_extraction(fastapi_client_simple):
+    test_client, _ = fastapi_client_simple
+
+    # Deposit JSON record
+    response = test_client.post(
+        f'/trr379_store/record/Person',
+        headers={'x-dumpthings-token': 'token_1'},
+        json=inlined_json_record
+    )
+    assert response.status_code == HTTP_200_OK
+
+    # Expect three records with no inlined data but links to the ids
+    for record_id, linked_id in (
+        ('trr379:root_element', 'trr379:child_element'),
+        ('trr379:child_element', 'trr379:grand_child_element'),
+        ('trr379:grand_child_element', None),
+    ):
+        response = test_client.get(
+            f'/trr379_store/record?id={record_id}',
+            headers={'x-dumpthings-token': 'token_1'},
+        )
+        assert response.status_code == HTTP_200_OK
+        record = response.json()
+        if linked_id:
+            assert linked_id in record['characterized_by']


### PR DESCRIPTION
Sub-records that are inlined via `relations` are extracted before the record is stored. All extracted sub-records are stored as well. Arbitrarily deep nesting is supported.

The sub-records are referenced in a `relations`-entries that have the id of the sub-records as key and a minimal record, containing only the record-id, as value, e.g.:

``` 
...
relations:
  <subrecord id one>:
    id: <subrecord id one>
  <another subrecord id>:
    id: <another subrecord id>
...
``` 

