### PR TITLE
Use a prefix for `http://purl.obolibrary.org/obo/` if it is defined in the LinkML-schema

### DIFF
--- a/dump_things_service/main.py
+++ b/dump_things_service/main.py
@@ -202,6 +202,7 @@ def store_record(
     stored_records = store.store_record(
         record=record,
         submitter_id=g_token_stores[token]['user_id'],
+        model=model,
     )
 
     if input_format == Format.ttl:

--- a/dump_things_service/tests/test_roundtrip.py
+++ b/dump_things_service/tests/test_roundtrip.py
@@ -7,11 +7,12 @@ json_record = {'pid': 'xyz:bbbb', 'given_name': 'John'}
 new_ttl_pid = 'xyz:cccc'
 
 ttl_record = """@prefix abc: <http://example.org/person-schema/abc/> .
+@prefix oxo: <http://purl.obolibrary.org/obo/> .
 @prefix xyz: <http://example.org/person-schema/xyz/> .
 
 xyz:HenryAdams a abc:Person ;
     abc:annotations [ a abc:Annotation ;
-            abc:annotation_tag <http://purl.obolibrary.org/obo/NCIT_C54269> ;
+            abc:annotation_tag oxo:NCIT_C54269 ;
             abc:annotation_value "test_user_1" ] ;
     abc:given_name "Henryöäß" .
 """

--- a/dump_things_service/tests/testschema.yaml
+++ b/dump_things_service/tests/testschema.yaml
@@ -2,9 +2,10 @@ id: http://example.org/person-schema
 name: person_schema
 prefixes:
   abc: http://example.org/person-schema/abc/
-  xyz: http://example.org/person-schema/xyz/
-  trr379: http://example.org/person-schema/trr379/
   linkml: https://w3id.org/linkml/
+  oxo: http://purl.obolibrary.org/obo/
+  trr379: http://example.org/person-schema/trr379/
+  xyz: http://example.org/person-schema/xyz/
 imports:
   - linkml:types
 default_range: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-    "fastapi[standard]",
     "aiohttp",
+    "fastapi[standard]",
+    "click==8.1.8",
     "fsspec",
     "linkml",
     "pydantic==2.8.0",

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -10,3 +10,7 @@ PyYAML
 rdflib
 requests
 uvicorn
+
+httpx
+pytest
+pytest-cov


### PR DESCRIPTION
This PR updates the handling of subscriber annotations.

1. During annotation adding: if the LinkML-schema defines a prefix for <http://purl.obolibrary.org/obo/>, this prefix will be used in the annotation.
2. During TTL-output generation: if the schema does not already define a prefix for <http://purl.obolibrary.org/obo/>, a prefix will be added temporarily for the TTL document generation. The prefix will be `obo`, unless that is already taken. If `obo` is not available `obo1`, `obo2`, `obo3`, ...  will be tried until a non-taken prefix is found.

