### PR TITLE
Support proper TTL <-> JSON conversion without `schema_type` and correct TTL result content

### DIFF
--- a/dump_things_service/main.py
+++ b/dump_things_service/main.py
@@ -206,7 +206,22 @@ def store_record(
     )
 
     if input_format == Format.ttl:
-        return PlainTextResponse(data, media_type='text/turtle')
+        return PlainTextResponse(
+            combine_ttl(
+                [
+                    convert_json_to_ttl(
+                        collection,
+                        record.__class__.__name__,
+                        cleaned_json(
+                            record.model_dump(mode='json', exclude_none=True),
+                            remove_keys=('@type', 'schema_type'),
+                        )
+                    )
+                    for record in stored_records
+                ]
+            ),
+            media_type='text/turtle',
+        )
     return JSONResponse(
         list(
             map(

--- a/dump_things_service/record.py
+++ b/dump_things_service/record.py
@@ -54,15 +54,14 @@ class RecordDirStore:
         record: BaseModel,
         submitter_id: str,
         model: Any,
-    ) -> list[BaseModel]:
+    ) -> Iterable[BaseModel]:
         final_records = self.extract_inlined(record, submitter_id)
         for final_record in final_records:
-            self.store_single_record(
+            yield self.store_single_record(
                 record=final_record,
                 submitter_id=submitter_id,
                 model=model,
             )
-        return final_records
 
     def extract_inlined(
         self,
@@ -134,6 +133,7 @@ class RecordDirStore:
         # Ensure all intermediate directories exist and save the YAML document
         storage_path.parent.mkdir(parents=True, exist_ok=True)
         storage_path.write_text(data, encoding='utf-8')
+        return record
 
     def annotate(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.tests.scripts]
-run = 'python -m pytest {args}'
+run = 'pushd datalad-concepts; ./tools/patch_linkml; popd; python -m pytest {args}'
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
 This PR improves the code that converts between JSON and TTL so that it works with `schema_type` attributes in JSON objects. It uses Pydantic to determine classes of JSON objects.

It also improves the HTTP result content when TTL is selected as a format. Previously, the posted TTL document was returned on success. With the introduction of submitter annotations, that is no longer identical to the stored record. This commit converts the stored records into TTL and returns them in a successful request, which means the results will contain the submitter annotations.

The new conversion code requires the `linkml_runtime_utils_yamlutils.diff` patch in datalad-concepts.
