### PR TITLE
Use fully expanded CURIEs in pid-search

### DIFF
--- a/dump_things_service/convert.py
+++ b/dump_things_service/convert.py
@@ -78,12 +78,14 @@ def convert_pydantic_to_ttl(
     collection_name: str,
     pydantic_object: BaseModel,
 ):
+    from dump_things_service.config import get_conversion_objects_for_collection
+
     return convert_format(
         target_class=pydantic_object.__class__.__name__,
         data=pydantic_object.model_dump(mode='json', exclude_none=True),
         input_format=Format.json,
         output_format=Format.ttl,
-        **instance_config.conversion_objects[instance_config.schemas[collection_name]],
+        **get_conversion_objects_for_collection(instance_config, collection_name),
     )
 
 
@@ -93,12 +95,14 @@ def convert_ttl_to_json(
     target_class: str,
     ttl: str,
 ) -> JSON:
+    from dump_things_service.config import get_conversion_objects_for_collection
+
     json_string = convert_format(
         target_class=target_class,
         data=ttl,
         input_format=Format.ttl,
         output_format=Format.json,
-        **instance_config.conversion_objects[instance_config.schemas[collection_name]],
+        **get_conversion_objects_for_collection(instance_config, collection_name),
     )
     return cleaned_json(json_loads(json_string))
 

--- a/dump_things_service/record.py
+++ b/dump_things_service/record.py
@@ -14,6 +14,7 @@ from dump_things_service import (
     JSON,
     config_file_name,
 )
+from dump_things_service.resolve_curie import resolve_curie
 from dump_things_service.utils import cleaned_json
 
 if TYPE_CHECKING:
@@ -167,7 +168,11 @@ class RecordDirStore:
         for path in self.root.rglob('*'):
             if path.is_file() and path.name not in ignored_files:
                 record = yaml.load(path.read_text(), Loader=yaml.SafeLoader)
-                if record['pid'] == pid:
+                iri = resolve_curie(
+                    self.model,
+                    record['pid'],
+                )
+                if iri == pid:
                     class_name = self._get_class_from_path(path)
                     return class_name, record
         return None, None

--- a/dump_things_service/resolve_curie.py
+++ b/dump_things_service/resolve_curie.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import types
+
+
+def resolve_curie(
+    model: types.ModuleType,
+    curie: str,
+) -> str:
+    if ":" not in curie:
+        return curie
+
+    if curie.startswith(('http://', 'https://')):
+        return curie
+
+    prefix, identifier = curie.split(':', 1)
+    prefix_value = model.linkml_meta.root.get('prefixes', {}).get(prefix)
+    if prefix_value is None:
+        return curie
+    return prefix_value['prefix_reference'] + identifier

--- a/dump_things_service/tests/test_basic.py
+++ b/dump_things_service/tests/test_basic.py
@@ -209,3 +209,17 @@ def test_unknown_token(fastapi_client_simple):
         headers={'x-dumpthings-token': 'unknown_token'},
     )
     assert response.status_code == HTTP_401_UNAUTHORIZED
+
+
+def test_curie_expansion(fastapi_client_simple):
+    test_client, _ = fastapi_client_simple
+
+    # Check that the pid is expanded correctly
+    response = test_client.get(
+        '/collection_1/record?pid=http%3A%2F%2Fexample.org%2Fperson-schema%2Fabc%2Fmode_test',
+    )
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {
+        'pid': 'abc:mode_test',
+        'given_name': 'mode_curated',
+    }


### PR DESCRIPTION
This PR modifies search to use a canonical PID representation, i.e, an expanded CURIE, for all PID comparisons when searching for a PID.

This solves one problem that was mentioned in issue #80 
