### PR TITLE
Add PID-mapping methods with two-stage directory hierarchy

### DIFF
--- a/dump_things_service/config.py
+++ b/dump_things_service/config.py
@@ -46,8 +46,10 @@ class ConfigError(Exception):
 class MappingMethod(enum.Enum):
     digest_md5 = 'digest-md5'
     digest_md5_p3 = 'digest-md5-p3'
+    digest_md5_p3_p3 = 'digest-md5-p3-p3'
     digest_sha1 = 'digest-sha1'
     digest_sha1_p3 = 'digest-sha1-p3'
+    digest_sha1_p3_p3 = 'digest-sha1-p3-p3'
     after_last_colon = 'after-last-colon'
 
 
@@ -143,6 +145,15 @@ def mapping_digest_p3(
     return Path(hex_digest[:3]) / (hex_digest[3:] + '.' + suffix)
 
 
+def mapping_digest_p3_p3(
+        hasher: Callable,
+        pid: str,
+        suffix: str,
+) -> Path:
+    hex_digest = get_hex_digest(hasher, pid)
+    return Path(hex_digest[:3]) / hex_digest[3:6] / (hex_digest[6:] + '.' + suffix)
+
+
 def mapping_digest(hasher: Callable, pid: str, suffix: str) -> Path:
     hex_digest = get_hex_digest(hasher, pid)
     return Path(hex_digest + '.' + suffix)
@@ -160,8 +171,10 @@ def mapping_after_last_colon(pid: str, suffix: str) -> Path:
 mapping_functions = {
     MappingMethod.digest_md5: partial(mapping_digest, hashlib.md5),
     MappingMethod.digest_md5_p3: partial(mapping_digest_p3, hashlib.md5),
+    MappingMethod.digest_md5_p3_p3: partial(mapping_digest_p3_p3, hashlib.md5),
     MappingMethod.digest_sha1: partial(mapping_digest, hashlib.sha1),
     MappingMethod.digest_sha1_p3: partial(mapping_digest_p3, hashlib.sha1),
+    MappingMethod.digest_sha1_p3_p3: partial(mapping_digest_p3_p3, hashlib.sha1),
     MappingMethod.after_last_colon: mapping_after_last_colon,
 }
 

--- a/dump_things_service/tests/fixtures.py
+++ b/dump_things_service/tests/fixtures.py
@@ -45,6 +45,12 @@ collections:
   collection_5:
     default_token: basic_access
     curated: {curated}/collection_5
+  collection_6:
+    default_token: basic_access
+    curated: {curated}/collection_6
+  collection_7:
+    default_token: basic_access
+    curated: {curated}/collection_7
   collection_trr379:
     default_token: basic_access
     curated: {curated}/collection_trr379
@@ -67,6 +73,12 @@ tokens:
         mode: READ_CURATED
         incoming_label: ''
       collection_5:
+        mode: READ_CURATED
+        incoming_label: ''
+      collection_6:
+        mode: READ_CURATED
+        incoming_label: ''
+      collection_7:
         mode: READ_CURATED
         incoming_label: ''
       collection_trr379:
@@ -151,7 +163,7 @@ def dump_stores_simple(tmp_path_factory):
     (tmp_path / config_file_name).write_text(global_config_text)
 
     default_entries = {
-        f'collection_{i}': [('Person', pid, test_record)] for i in range(1, 6)
+        f'collection_{i}': [('Person', pid, test_record)] for i in range(1, 8)
     }
     default_entries['collection_1'].extend(
         [
@@ -173,6 +185,8 @@ def dump_stores_simple(tmp_path_factory):
             'collection_3': (str(schema_path), 'digest-sha1'),
             'collection_4': (str(schema_path), 'digest-sha1-p3'),
             'collection_5': (str(schema_path), 'after-last-colon'),
+            'collection_6': (str(schema_path), 'digest-md5-p3-p3'),
+            'collection_7': (str(schema_path), 'digest-sha1-p3-p3'),
             'collection_trr379': (
                 'https://concepts.trr379.de/s/base/unreleased.yaml',
                 'digest-md5',

--- a/dump_things_service/tests/test_basic.py
+++ b/dump_things_service/tests/test_basic.py
@@ -29,7 +29,7 @@ unicode_record = {
 
 def test_search_by_pid(fastapi_client_simple):
     test_client, _ = fastapi_client_simple
-    for i in range(1, 6):
+    for i in range(1, 8):
         response = test_client.get(
             f'/collection_{i}/record?pid={pid}',
             headers={'x-dumpthings-token': 'basic_access'},
@@ -40,7 +40,7 @@ def test_search_by_pid(fastapi_client_simple):
 
 def test_search_by_pid_no_token(fastapi_client_simple):
     test_client, _ = fastapi_client_simple
-    for i in range(1, 6):
+    for i in range(1, 8):
         response = test_client.get(
             f'/collection_{i}/record?pid={pid}',
         )
@@ -114,7 +114,7 @@ def test_encoding(fastapi_client_simple):
 
 def test_global_store_write_fails(fastapi_client_simple):
     test_client, _ = fastapi_client_simple
-    for i in range(1, 6):
+    for i in range(1, 8):
         # Since we provide no token, the default token will be used. This will
         # only allow reading from curated, not posting.
         response = test_client.post(


### PR DESCRIPTION
This PR adds two new PID-mapping methods, `digest-md5-p3-p3`, and `digest-sha1-p3-p3`. These methods use a two-stage directory hierarchy when mapping PIDs to file names. The first directory level names consist of the first 3 digits of
the hash, the second directory level names consist of the next 3 digits of the hash, and the filename consists of the remaining digits of the hash and the format extension, e.g., `.yaml`