### PR TITLE
Add `schema_type` attribute to all JSON-records returned by the API

### DIFF
--- a/dump_things_service/record.py
+++ b/dump_things_service/record.py
@@ -214,11 +214,11 @@ class RecordDirStore:
 
         # Convert the record object into a YAML object
         data = yaml.dump(
-            # Remove the `schema_type` entry from the record. It does not belong
-            # to the declared classes.
+            # Remove the `schema_type` entry from the record. The type is
+            # defined by the path under which the record is stored.
             data=cleaned_json(
                 record.model_dump(exclude_none=True, mode='json'),
-                remove_keys=('schema_type',),
+                remove_keys=('schema_type', '@type'),
             ),
             sort_keys=False,
             allow_unicode=True,

--- a/dump_things_service/tests/test_basic.py
+++ b/dump_things_service/tests/test_basic.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest  # F401
 
 from .. import (
@@ -15,6 +13,7 @@ from .create_store import (
 from .test_utils import basic_write_locations
 
 extra_record = {
+    'schema_type': 'abc:Person',
     'pid': 'abc:aaaa',
     'given_name': 'DavidÖÄÜ',
 }
@@ -35,7 +34,11 @@ def test_search_by_pid(fastapi_client_simple):
             headers={'x-dumpthings-token': 'basic_access'},
         )
         assert response.status_code == HTTP_200_OK
-        assert json.loads(response.text) == {'pid': pid, 'given_name': given_name}
+        assert response.json() == {
+            'schema_type': 'abc:Person',
+            'pid': pid,
+            'given_name': given_name,
+        }
 
 
 def test_search_by_pid_no_token(fastapi_client_simple):
@@ -45,7 +48,11 @@ def test_search_by_pid_no_token(fastapi_client_simple):
             f'/collection_{i}/record?pid={pid}',
         )
         assert response.status_code == HTTP_200_OK
-        assert response.json() == {'pid': pid, 'given_name': given_name}
+        assert response.json() == {
+            'schema_type': 'abc:Person',
+            'pid': pid,
+            'given_name': given_name,
+        }
 
 
 def test_store_record(fastapi_client_simple):
@@ -79,7 +86,11 @@ def test_store_record(fastapi_client_simple):
             f'/collection_{i}/records/Person',
             headers={'x-dumpthings-token': 'basic_access'},
         )
-        assert response.json() == [{'pid': pid, 'given_name': given_name}]
+        assert response.json() == [{
+            'schema_type': 'abc:Person',
+            'pid': pid,
+            'given_name': given_name,
+        }]
 
     # Check that subclasses are retrieved
     for i, token in basic_write_locations:
@@ -89,7 +100,11 @@ def test_store_record(fastapi_client_simple):
         )
         cleaned_response = cleaned_json(response.json(), remove_keys=('annotations',))
         assert extra_record in cleaned_response
-        assert {'pid': pid, 'given_name': given_name} in cleaned_response
+        assert {
+           'schema_type': 'abc:Person',
+            'pid': pid,
+            'given_name': given_name
+        } in cleaned_response
 
 
 def test_encoding(fastapi_client_simple):
@@ -220,6 +235,7 @@ def test_curie_expansion(fastapi_client_simple):
     )
     assert response.status_code == HTTP_200_OK
     assert response.json() == {
+        'schema_type': 'abc:Person',
         'pid': 'abc:mode_test',
         'given_name': 'mode_curated',
     }

--- a/dump_things_service/tests/test_roundtrip.py
+++ b/dump_things_service/tests/test_roundtrip.py
@@ -3,7 +3,8 @@ import pytest  # noqa F401
 from .. import HTTP_200_OK
 from ..utils import cleaned_json
 
-json_record = {'pid': 'xyz:bbbb', 'given_name': 'John'}
+json_record = {'schema_type': 'abc:Person', 'pid': 'xyz:bbbb', 'given_name': 'John'}
+json_record_out = {'schema_type': 'abc:Person', **json_record}
 new_ttl_pid = 'xyz:cccc'
 
 ttl_record = """@prefix abc: <http://example.org/person-schema/abc/> .
@@ -16,6 +17,19 @@ xyz:HenryAdams a abc:Person ;
             abc:annotation_value "test_user_1" ] ;
     abc:given_name "Henryöäß" .
 """
+
+ttl_result_record = """@prefix abc: <http://example.org/person-schema/abc/> .
+@prefix oxo: <http://purl.obolibrary.org/obo/> .
+@prefix xyz: <http://example.org/person-schema/xyz/> .
+
+xyz:HenryAdams a abc:Person ;
+    abc:annotations [ a abc:Annotation ;
+            abc:annotation_tag oxo:NCIT_C54269 ;
+            abc:annotation_value "test_user_1" ] ;
+    abc:given_name "Henryöäß" ;
+    abc:schema_type "Person" .
+"""
+
 new_json_pid = 'xyz:HenryBaites'
 
 
@@ -55,9 +69,9 @@ def test_json_ttl_json(fastapi_client_simple):
     )
     assert response.status_code == HTTP_200_OK
     json_object = cleaned_json(response.json(), remove_keys=('annotations',))
-    assert json_object != json_record
-    json_object['pid'] = json_record['pid']
-    assert json_object == json_record
+    assert json_object != json_record_out
+    json_object['pid'] = json_record_out['pid']
+    assert json_object == json_record_out
 
 
 def test_ttl_json_ttl(fastapi_client_simple):

--- a/dump_things_service/tests/test_roundtrip_trr379.py
+++ b/dump_things_service/tests/test_roundtrip_trr379.py
@@ -7,6 +7,10 @@ json_record = {
     'pid': 'trr379:test_john_json',
     'given_name': 'Johnöüß',
 }
+json_record_out = {
+    'schema_type': 'dlsocial:Person',
+    **json_record,
+}
 
 new_ttl_pid = 'trr379:another_john_json'
 
@@ -80,9 +84,9 @@ def test_json_ttl_json_trr379(fastapi_client_simple):
     )
     assert response.status_code == HTTP_200_OK
     json_object = cleaned_json(response.json(), remove_keys=('annotations',))
-    assert json_object != json_record
+    assert cleaned_json(json_object, remove_keys=('schema_type',)) != json_record
     json_object['pid'] = json_record['pid']
-    assert json_object == json_record
+    assert json_object == json_record_out
 
 
 def test_ttl_json_ttl_trr379(fastapi_client_simple):

--- a/dump_things_service/tests/testschema.yaml
+++ b/dump_things_service/tests/testschema.yaml
@@ -47,6 +47,8 @@ classes:
       pid:
         identifier: true
         required: true
+      schema_type:
+        range: string
 
   Annotation:
     slots:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,13 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.tests.scripts]
-#run = 'pushd datalad-concepts; ./tools/patch_linkml; popd; python -m pytest {args}'
 run = 'python -m pytest {args}'
+
+post-install-commands = [
+    "pushd datalad-concepts",
+    "./tools/call_patch_linkml",
+    "popd",
+]
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,8 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.tests.scripts]
-run = 'pushd datalad-concepts; ./tools/patch_linkml; popd; python -m pytest {args}'
+#run = 'pushd datalad-concepts; ./tools/patch_linkml; popd; python -m pytest {args}'
+run = 'python -m pytest {args}'
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
This change amends the JSON-results that are returned by the API when storing or fetching records. The returned JSON-records will now always contain a `schema-type` attribute with the correct CURIE or URI.
