### PR TITLE
Add an `--export-tree` and an `--export-json` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ The service supports the following command line parameters:
 - `--export-to`: export all data in `<storage root>` as JSON to the given path and exit. If the path is `-`, the data will be written to `stdout`. The data in `<storage root>` will not be modified. This is useful to export the data for backup or migration purposes. The file will contain all records in all collections. NOTE: the resulting file might be large.
 
 
+- `--export-json`: an alias for `export-to`.
+
+
+- `--export-tree`: export all data in `<storage root>` as file tree at the given path. The tree confirms to the [dumpthings-specification](https://concepts.datalad.org/dump-things/).
+
+
 - `--error-mode`: if set, the service will run even if an error prevents it from starting properly. It will report that it executes in error mode on every request. This can be useful if the service is deployed automatically and no other monitoring method is available.
 
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ type: collections
 version: 1
 
 collections:
-  collection_1:
+  datamgt:
     default_token: anon_read
     curated: datamgt/curated
     incoming: datamgt

--- a/dump_things_service/backends/__init__.py
+++ b/dump_things_service/backends/__init__.py
@@ -106,6 +106,7 @@ class BackendResultList(LazyList):
         """
         raise NotImplementedError
 
+
 class StorageBackend(metaclass=ABCMeta):
     def __init__(
         self,

--- a/dump_things_service/config.py
+++ b/dump_things_service/config.py
@@ -346,6 +346,10 @@ def process_config_object(
                     msg = f'Token `{token_name}` with mode {token_collection_info.mode} must not have an empty `incoming_label`'
                     raise ConfigError(msg)
 
+                if any(c in token_collection_info.incoming_label for c in ('\\', '/')):
+                    msg = f'Incoming label for token `{token_name}` must not contain slashes or backslashes: `{token_collection_info.incoming_label}`'
+                    raise ConfigError(msg)
+
                 if collection_name not in instance_config.zones:
                     instance_config.zones[collection_name] = {}
                 instance_config.zones[collection_name][token_name] = token_collection_info.incoming_label

--- a/dump_things_service/export/__init__.py
+++ b/dump_things_service/export/__init__.py
@@ -1,12 +1,9 @@
-
-from pathlib import Path
-
 from .json import export_json
 from .tree import export_tree
 
 
 exporter_info = {
-    'to': (export_json, Path),
-    'json': (export_json, Path),
-    'tree': (export_tree, Path),
+    'to': export_json,
+    'json': export_json,
+    'tree': export_tree,
 }

--- a/dump_things_service/export/__init__.py
+++ b/dump_things_service/export/__init__.py
@@ -1,0 +1,12 @@
+
+from pathlib import Path
+
+from .json import export_json
+from .tree import export_tree
+
+
+exporter_info = {
+    'to': (export_json, Path),
+    'json': (export_json, Path),
+    'tree': (export_tree, Path),
+}

--- a/dump_things_service/export/json.py
+++ b/dump_things_service/export/json.py
@@ -36,12 +36,12 @@ def _lookahead(iterable):
 
 def export_json(
     instance_config: InstanceConfig,
-    destination: Path,
+    destination: str,
 ):
-    if destination == Path('-'):
+    if destination == '-':
         output = sys.stdout
     else:
-        output = destination.open('wt', encoding='utf-8')
+        output = Path(destination).open('wt', encoding='utf-8')
 
     output.write('{\n')
     for collection, is_last in _lookahead(instance_config.collections):

--- a/dump_things_service/export/json.py
+++ b/dump_things_service/export/json.py
@@ -34,7 +34,7 @@ def _lookahead(iterable):
     yield last, True
 
 
-def export(
+def export_json(
     instance_config: InstanceConfig,
     destination: Path,
 ):

--- a/dump_things_service/export/tree.py
+++ b/dump_things_service/export/tree.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import yaml
+
+from dump_things_service.config import (
+    InstanceConfig,
+    get_mapping_function_by_name,
+)
+from dump_things_service.model import get_classes
+from dump_things_service.store.model_store import ModelStore
+
+
+idfx = get_mapping_function_by_name('digest-md5-p3-p3')
+
+
+def export_tree(
+    instance_config: InstanceConfig,
+    destination: Path,
+):
+    if destination.exists() and not destination.is_dir():
+        msg = 'The export_tree destination path must be a directory.'
+        raise ValueError(msg)
+
+    destination.mkdir(parents=True, exist_ok=True)
+    for collection in instance_config.collections:
+        export_collection(
+            instance_config,
+            collection,
+            destination,
+        )
+
+
+def export_collection(
+        instance_config: InstanceConfig,
+        collection: str,
+        destination: Path,
+):
+    collection_destination = destination / collection
+    collection_destination.mkdir(parents=True, exist_ok=True)
+
+    config_content = (
+        "type: records\n"
+        "version: 1\n"
+        f"schema: {instance_config.schemas[collection]}\n"
+        "format: yaml\n"
+        "idfx: digest-sha256-p3-p3\n"
+    )
+
+    curated_destination = collection_destination / 'curated'
+    curated_destination.mkdir(parents=True, exist_ok=True)
+    (curated_destination / '.dumpthings.yaml').write_text(config_content)
+    export_classes(instance_config.curated_stores[collection], curated_destination)
+
+    # Determine stores for incoming zones
+    zones = {
+        label: instance_config.token_stores[token]['collections'].get(collection, {}).get('store')
+        for token, label in instance_config.zones.get(collection, {}).items()
+        if instance_config.token_stores[token]['collections'].get(collection, {}).get('store') is not None
+    }
+
+    if zones:
+        incoming_destination = collection_destination / 'incoming'
+        for zone, store in zones.items():
+            zone_destination = incoming_destination / zone
+            zone_destination.mkdir(parents=True, exist_ok=True)
+            (zone_destination / '.dumpthings.yaml').write_text(config_content)
+            export_classes(store, zone_destination)
+
+
+def export_classes(
+    store: ModelStore,
+    destination: Path,
+):
+    class_names = get_classes(store.model)
+    for class_name in class_names:
+
+        # We know that pure `Thing` instances are not stored in the store.
+        if class_name == 'Thing':
+            continue
+
+        record_infos = store.get_objects_of_class(class_name, include_subclasses=False)
+        if record_infos:
+            class_destination = destination / class_name
+            class_destination.mkdir(parents=True, exist_ok=True)
+            for record_info in record_infos:
+                json_object = record_info.json_object
+                instance_destination = class_destination / idfx(
+                    json_object['pid'],
+                    'yaml',
+                )
+                instance_destination.parent.mkdir(parents=True, exist_ok=True)
+                instance_destination.write_text(
+                    yaml.dump(
+                        data=json_object,
+                        sort_keys=False,
+                        allow_unicode=True,
+                        default_flow_style=False,
+                    )
+                )

--- a/dump_things_service/main.py
+++ b/dump_things_service/main.py
@@ -172,8 +172,7 @@ for switch in ('to', 'json', 'tree'):
         if g_error:
             sys.stderr.write('ERROR: Configuration errors detected, cannot export store.')
             sys.exit(1)
-        exporter, argument_converter = exporter_info[switch]
-        exporter(g_instance_config, argument_converter(argument))
+        exporter_info[switch](g_instance_config, argument)
         sys.exit(0)
 
 

--- a/dump_things_service/main.py
+++ b/dump_things_service/main.py
@@ -62,7 +62,7 @@ from dump_things_service.converter import (
     ConvertingList,
 )
 from dump_things_service.dynamic_endpoints import create_endpoints
-from dump_things_service.export import export
+from dump_things_service.export import exporter_info
 from dump_things_service.model import (
     get_classes,
     get_subclasses,
@@ -119,6 +119,18 @@ parser.add_argument(
     help="Export the store to the file FILE_NAME and exit the process. If FILE_NAME is `-', the data is written to stdout.",
 )
 parser.add_argument(
+    '--export-json',
+    default='',
+    metavar='FILE_NAME',
+    help="Export the store to the file FILE_NAME and exit the process. If FILE_NAME is `-', the data is written to stdout.",
+)
+parser.add_argument(
+    '--export-tree',
+    default='',
+    metavar='DIRECTORY_NAME',
+    help="Export the store to a dumpthings-conformant tree at DIRECTORY_NAME and exit the process. If DIRECTORY_NAME does not exist, the service will try to create it.",
+)
+parser.add_argument(
     'store',
     help='The root of the data stores, it should contain a global_store and token_stores.',
 )
@@ -144,7 +156,6 @@ try:
         config_file=config_path,
         order_by=arguments.sort_by,
         globals_dict=globals(),
-        create_models=not arguments.export_to,
     )
 except ConfigError:
     logger.exception(
@@ -155,12 +166,15 @@ except ConfigError:
     g_instance_config = None
 
 
-if arguments.export_to:
-    if g_error:
-        sys.stderr.write('ERROR: Configuration errors detected, cannot export store.')
-        sys.exit(1)
-    export(g_instance_config, Path(arguments.export_to))
-    sys.exit(0)
+for switch in ('to', 'json', 'tree'):
+    argument = getattr(arguments, 'export_' + switch)
+    if argument:
+        if g_error:
+            sys.stderr.write('ERROR: Configuration errors detected, cannot export store.')
+            sys.exit(1)
+        exporter, argument_converter = exporter_info[switch]
+        exporter(g_instance_config, argument_converter(argument))
+        sys.exit(0)
 
 
 app = FastAPI()

--- a/dump_things_service/store/model_store.py
+++ b/dump_things_service/store/model_store.py
@@ -27,7 +27,7 @@ submitter_class = 'NCIT_C54269'
 submitter_namespace = 'http://purl.obolibrary.org/obo/'
 
 
-class ModelStore:
+class _ModelStore:
     def __init__(
         self,
         schema: str,
@@ -170,3 +170,26 @@ class ModelStore:
         else:
             class_names = [class_name]
         return self.backend.get_records_of_classes(class_names)
+
+
+_existing_model_stores = {}
+
+
+def ModelStore(  # noqa: N802
+    schema: str,
+    backend: StorageBackend,
+) -> _ModelStore:
+    """
+    Create a unique model store for the given schema and backend.
+
+    :param schema: The schema to use for the model store.
+    :param backend: The storage backend to use.
+    :return: An instance of _ModelStore.
+    """
+    existing_model_store, _ = _existing_model_stores.get(id(backend), (None, None))
+    if not existing_model_store:
+        existing_model_store = _ModelStore(schema, backend)
+        # We store a pointer to the backend in the value to ensure that the
+        # backend object exists while we use its `id` as a key.
+        _existing_model_stores[id(backend)] = existing_model_store, backend
+    return existing_model_store


### PR DESCRIPTION
This PR adds two export commands:

- `--export-tree`: exports a store to a tree structure, compatible with the [dumpthings-specification](https://concepts.datalad.org/dump-things/)
- `--export-json`: exports a store to a JSON-file
