### PR TITLE
Add PyPI availability badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
 ### Dump Things Service
+
+[![PyPI version fury.io](https://badge.fury.io/py/dump-things-service.svg)](https://pypi.python.org/pypi/dump-things-service/)
 
 This is an implementation of a service that allows to store and retrieve data that is structured according to given schemata.
 


### PR DESCRIPTION
The idea is to make it more immediately obvious that this can be obtained from PyPI, what the package name is (it is different), and what version is available.