### PR TITLE
Enforce prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Bugfixes
 
-- Fix a missing definition error that lead to server crahes.
+- Fix a missing definition error that lead to server crashes.
 
 
 # 3.6.0 (2025-09-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# x.x.x (2025-xx-xx)
+
+## New features
+
+- Report an error if a `pid` in CURIE format, i.e., with a prefix, cannot be
+  resolved because the prefix is unknown.
+
+
 # 3.6.1 (2025-09-28)
 
 ## Bugfixes

--- a/dump_things_service/config.py
+++ b/dump_things_service/config.py
@@ -29,6 +29,7 @@ from dump_things_service.backends.sqlite import (
     record_file_name as sqlite_record_file_name,
 )
 from dump_things_service.converter import get_conversion_objects
+from dump_things_service.exceptions import ConfigError
 from dump_things_service.model import get_model_for_schema
 from dump_things_service.store.model_store import ModelStore
 from dump_things_service.token import (
@@ -48,10 +49,6 @@ ignored_files = {'.', '..', config_file_name}
 
 
 _global_config_instance = None
-
-
-class ConfigError(Exception):
-    pass
 
 
 class MappingMethod(enum.Enum):

--- a/dump_things_service/converter.py
+++ b/dump_things_service/converter.py
@@ -25,7 +25,6 @@ from dump_things_service.model import (
     get_model_for_schema,
     get_schema_model_for_schema,
 )
-from dump_things_service.resolve_curie import resolve_curie
 from dump_things_service.utils import cleaned_json
 
 if TYPE_CHECKING:
@@ -83,7 +82,7 @@ def get_conversion_objects(schema: str):
         }
         # Add types to support explicit type clauses in TTL
         for type_definition in schema_view.all_types().values():
-            uri = resolve_curie(model, type_definition.uri)
+            uri = schema_view.expand_curie(type_definition.uri)
             add_type_validator(
                 uri_ref=uri,
                 regex=type_definition.pattern,

--- a/dump_things_service/curated.py
+++ b/dump_things_service/curated.py
@@ -25,12 +25,14 @@ from dump_things_service.api_key import api_key_header_scheme
 from dump_things_service.backends import StorageBackend
 from dump_things_service.backends.schema_type_layer import _SchemaTypeLayer
 from dump_things_service.config import get_config
+from dump_things_service.exceptions import CurieResolutionError
 from dump_things_service.lazy_list import ModifierList
 from dump_things_service.store.model_store import ModelStore
 from dump_things_service.utils import (
     check_collection,
     cleaned_json,
     resolve_hashed_token,
+    wrap_http_exception,
 )
 
 if TYPE_CHECKING:
@@ -340,8 +342,9 @@ async def store_curated_record(
         remove_keys=('@type',),
     )
 
-    backend.add_record(
-        model_store.pid_to_iri(pid),
-        class_name,
-        json_object,
-    )
+    with wrap_http_exception(CurieResolutionError):
+        backend.add_record(
+            model_store.pid_to_iri(pid),
+            class_name,
+            json_object,
+        )

--- a/dump_things_service/exceptions.py
+++ b/dump_things_service/exceptions.py
@@ -1,0 +1,6 @@
+class ConfigError(Exception):
+    pass
+
+
+class CurieResolutionError(Exception):
+    pass

--- a/dump_things_service/incoming.py
+++ b/dump_things_service/incoming.py
@@ -26,6 +26,7 @@ from dump_things_service.api_key import api_key_header_scheme
 from dump_things_service.backends import StorageBackend
 from dump_things_service.backends.schema_type_layer import _SchemaTypeLayer
 from dump_things_service.config import get_config
+from dump_things_service.exceptions import CurieResolutionError
 from dump_things_service.lazy_list import ModifierList
 from dump_things_service.store.model_store import ModelStore
 from dump_things_service.utils import (
@@ -35,7 +36,7 @@ from dump_things_service.utils import (
     create_token_store,
     get_config_labels,
     get_on_disk_labels,
-    resolve_hashed_token,
+    resolve_hashed_token, wrap_http_exception,
 )
 
 if TYPE_CHECKING:
@@ -428,8 +429,9 @@ async def store_incoming_record(
         remove_keys=('@type',),
     )
 
-    backend.add_record(
-        model_store.pid_to_iri(pid),
-        class_name,
-        json_object,
-    )
+    with wrap_http_exception(CurieResolutionError):
+        backend.add_record(
+            model_store.pid_to_iri(pid),
+            class_name,
+            json_object,
+        )

--- a/dump_things_service/main.py
+++ b/dump_things_service/main.py
@@ -64,6 +64,7 @@ from dump_things_service.curated import (
     router as curated_router,
     store_curated_record,  # noqa F401 -- used by generated code
 )
+from dump_things_service.exceptions import CurieResolutionError
 from dump_things_service.incoming import (
     create_incoming_endpoints,
     router as incoming_router,
@@ -292,7 +293,8 @@ def store_record(
     else:
         record = data
 
-    stored_records = store.store_object(obj=record, submitter=user_id)
+    with wrap_http_exception(CurieResolutionError):
+        stored_records = store.store_object(obj=record, submitter=user_id)
 
     if input_format == Format.ttl:
         format_converter = FormatConverter(

--- a/dump_things_service/resolve_curie.py
+++ b/dump_things_service/resolve_curie.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from dump_things_service.exceptions import CurieResolutionError
+
 if TYPE_CHECKING:
     import types
 
@@ -13,11 +15,20 @@ def resolve_curie(
     if ':' not in curie:
         return curie
 
-    if curie.startswith(('http://', 'https://')):
+    if (
+        curie.startswith(('http://', 'https://'))
+        or (curie[0] == '<' and curie[-1] == '>')
+        or (curie[0] == '[' and curie[-1] == ']')
+    ):
         return curie
 
     prefix, identifier = curie.split(':', 1)
     prefix_value = model.linkml_meta.root.get('prefixes', {}).get(prefix)
     if prefix_value is None:
-        return curie
+        msg = (
+            f'cannot resolve CURIE "{curie}". No such prefix: "{prefix}" in '
+            f'schema: {model.linkml_meta.root["id"]}'
+        )
+        raise CurieResolutionError(msg)
+
     return prefix_value['prefix_reference'] + identifier

--- a/dump_things_service/tests/create_store.py
+++ b/dump_things_service/tests/create_store.py
@@ -39,7 +39,7 @@ given_name: {given_name}
 schema_type: abc:Person
 """
 
-pid_trr = 'flatsocial:amadeus'
+pid_trr = 'dlflatsocial:amadeus'
 given_name_trr = 'AmadeusÜÄß'
 test_record_trr = f"""pid: {pid_trr}
 given_name: {given_name_trr}

--- a/dump_things_service/tests/test_pid_resolution.py
+++ b/dump_things_service/tests/test_pid_resolution.py
@@ -1,0 +1,40 @@
+
+
+from .. import HTTP_400_BAD_REQUEST
+
+
+def test_store_record_with_unresolvable_pid(fastapi_client_simple):
+    test_client, _ = fastapi_client_simple
+
+    # Store a record in two collections
+    response = test_client.post(
+        f'/collection_1/record/Person',
+        headers={'x-dumpthings-token': 'token-1'},
+        json={'pid': 'unknown_prefix:test_pid'},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+
+
+
+def test_store_record_curated_with_unresolvable_pid(fastapi_client_simple):
+    test_client, _ = fastapi_client_simple
+
+    # Store a record in two collections
+    response = test_client.post(
+        f'/collection_1/curated/record/Person',
+        headers={'x-dumpthings-token': 'token_admin'},
+        json={'pid': 'unknown_prefix:test_pid'},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+
+
+def test_store_record_incoming_with_unresolvable_pid(fastapi_client_simple):
+    test_client, _ = fastapi_client_simple
+
+    # Store a record in two collections
+    response = test_client.post(
+        f'/collection_1/incoming/in_token_1/record/Person',
+        headers={'x-dumpthings-token': 'token_admin'},
+        json={'pid': 'unknown_prefix:test_pid'},
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST

--- a/dump_things_service/tests/testschema.yaml
+++ b/dump_things_service/tests/testschema.yaml
@@ -2,9 +2,13 @@ id: http://example.org/person-schema
 name: person_schema
 prefixes:
   abc: http://example.org/person-schema/abc/
+  dlflatsocial: https://concepts.datalad.org/s/flat-social/unreleased/
   linkml: https://w3id.org/linkml/
   oxo: http://purl.obolibrary.org/obo/
+  shex: http://www.w3.org/ns/shex#
+  schema: http://schema.org/
   trr379: http://example.org/person-schema/trr379/
+  xsd: http://www.w3.org/2001/XMLSchema#
   xyz: http://example.org/person-schema/xyz/
 imports:
   - linkml:types


### PR DESCRIPTION
Throw an exception if a prefix in a pid is undefined. 

If a `pid` is in CURIE format and cannot be resolved because the prefix is unknown, an error during storage will be reported.
    
SafeCURIEs will not be resolved. A SafeCURIE is a CURIE with one of the following properties:
    
1. It starts with the prefixes `http:` or `https:`
2. It is enclosed in `[` and `]`.
3. It is enclosed in `<` and `>`.
